### PR TITLE
docs(config): add cross-platform .gitattributes and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Default: normalize text files to LF in the repository
+* text=auto eol=lf
+
+# Keep common source/config/docs as UTF-8 + LF
+*.md   text eol=lf working-tree-encoding=UTF-8
+*.py   text eol=lf working-tree-encoding=UTF-8
+*.toml text eol=lf working-tree-encoding=UTF-8
+*.yaml text eol=lf working-tree-encoding=UTF-8
+*.yml  text eol=lf working-tree-encoding=UTF-8
+*.json text eol=lf working-tree-encoding=UTF-8
+
+# Windows-native scripts may use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# DICOM and image/binary assets
+*.dcm  binary
+*.dicom binary
+*.nii  binary
+*.nii.gz binary
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.tif  binary
+*.tiff binary
+*.bmp  binary
+*.gif  binary
+*.pdf  binary


### PR DESCRIPTION
### Motivation
- Prevent mixed line endings and editor/configuration differences between Windows and Ubuntu by enforcing repository conventions (UTF-8 + LF for source/docs, allow CRLF for Windows scripts, and treat DICOM/images as binary). 

### Description
- Add `/.gitattributes` that normalizes text to LF (`* text=auto eol=lf`), enforces UTF-8+LF for `*.md`, `*.py`, `*.toml`, `*.yaml`, `*.yml`, `*.json`, allows CRLF for `*.bat`, `*.cmd`, `*.ps1`, and marks DICOM and image-like assets (e.g. `*.dcm`, `*.dicom`, `*.nii`, `*.png`, `*.jpg`, etc.) as `binary`, and add `/.editorconfig` that sets `charset = utf-8`, `end_of_line = lf` by default, `insert_final_newline = true`, `trim_trailing_whitespace = true` (disabled for `*.md`), `indent_style = space` with `indent_size = 2` (and `indent_size = 4` for `*.py`), and `end_of_line = crlf` for Windows scripts; only these two files were added per the constraint. 

### Testing
- No automated tests were run because this is a repository/editor configuration-only change that does not affect executable code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f148440260832e8a4095319b3dadb7)