### PR TITLE
Rename Agents.md to AGENTS.md and make sync command explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 3. **実装 (Developer):** 承認された OpenSpec に従い、Developer Agent がコードを実装・検証する。
 4. **報告 (Developer):** テストがすべてPASSしたことを人間に報告し、`gh pr create` でPRを作成してURLを渡す。
 5. **マージ (Human):** 人間がGitHub画面上で「Merge pull request」を押す。
-6. **同期 (Developer):** マージ完了の連絡を受けたら、`git checkout main` → `git pull` → `git branch -d <作業ブランチ>` で後片付けする。
+6. **同期 (Developer):** マージ完了の連絡を受けたら、`git checkout main` → `git pull origin main` → `git branch -d <作業ブランチ>` で後片付けする。
 
 ---
 


### PR DESCRIPTION
### Motivation
- Normalize the agent docs filename and reduce ambiguity in the sync instructions by explicitly specifying the remote when pulling `main`.

### Description
- Rename `Agents.md` to `AGENTS.md` (case-normalization) and update the sync step to use `git pull origin main` instead of a plain `git pull`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d783550832e97f873d1530543d7)