### PR TITLE
Fix shebang typo in anonymization check scripts

### DIFF
--- a/check_anonymization.py
+++ b/check_anonymization.py
@@ -1,4 +1,4 @@
-#!/usr/8/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/check_anonymization_gui.py
+++ b/check_anonymization_gui.py
@@ -1,4 +1,4 @@
-#!/usr/8/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
### Motivation
- Fix malformed shebang in anonymization checker scripts so they launch correctly on Unix systems.

### Description
- Replaced the first line in `check_anonymization.py` and `check_anonymization_gui.py` from `#!/usr/8/env python3` to `#!/usr/bin/env python3` and made no other changes.

### Testing
- Ran `rg -n '/usr/8/env'` to confirm no remaining occurrences and inspected `git diff` to verify only the intended shebang changes; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d786dc14832eb51afb97aedcab9a)