### PR TITLE
feat: Universal DICOM Template の実装

### DIFF
--- a/changes/004_universal_template.md
+++ b/changes/004_universal_template.md
@@ -1,0 +1,46 @@
+# Proposal: 004 Universal DICOM Template の実装
+
+- Status: ✅ APPROVED
+- Author: Antigravity
+- Date: 2026-04-30
+
+## 1. 背景 / 目的
+
+### 現状の問題
+PHITSからDICOM（RTDOSE等）へ変換する際、ベースとなる臨床DICOMファイル（原本）の構造がメーカーや出力設定によって異なり、変換スクリプトが特定のタグ構成に依存している場合にエラーが発生したり、出力されたDICOMがビューアで正しく表示されなかったりすることがあります。
+
+### 解決策
+「Universal Template」戦略を採用します。これは、あらかじめ用意した「標準的でクリーンなDICOMファイル（テンプレート）」をベースとし、そこに原本DICOMから抽出した特定の幾何学的パラメータ（座標、解像度等）や患者情報を注入して新しいDICOMを生成する手法です。これにより、出力ファイルの構造が常に一定に保たれ、システムの安定性が向上します。
+
+## 2. 変更内容
+
+### 2.1 新規モジュール `rt_dicom_toolkit/template/`
+- **`engine.py`**: テンプレート操作の中核ロジック。
+  - `DICOMTemplateEngine` クラスを実装。
+  - `inject_tags(template_path, source_tags_dict)`: タグの注入。
+  - `sync_geometry(template_path, source_dicom_path)`: 幾何学情報の同期。
+- **`tags.py`**: 同期すべき標準タグリストの定義。
+  - `GEOMETRY_TAGS`: `ImagePositionPatient`, `PixelSpacing`, `Rows`, `Columns` 等。
+  - `PATIENT_TAGS`: `PatientName`, `PatientID`, `StudyInstanceUID` 等。
+
+### 2.2 CLIの拡張 (`rt_dicom_toolkit/cli.py`)
+- `--template` オプションの追加。
+- `template-base` コマンド（または既存コマンドのサブオプション）の実装。
+
+### 2.3 GUIの拡張 (`rt_dicom_toolkit/gui/`)
+- テンプレートファイルを選択するUI要素の追加。
+
+## 3. 影響範囲 / リスク
+- **既存の匿名化機能**: 影響なし。本機能は独立したツール/モードとして提供。
+- **モダリティ不一致**: テンプレート（例: CT）と原本（例: RTDOSE）のモダリティが異なる場合、手動でのタグ調整が必要になる可能性がある。初期実装では警告を出す。
+
+## 4. テスト・検証計画
+
+### 4.1 ユニットテスト
+- テンプレートファイルに特定の値が正しく注入されることを確認。
+- 幾何学情報（座標・間隔）が原本と一致するように更新されることを確認。
+
+### 4.2 統合テスト
+- `DICOM/sample.dcm` をテンプレートとして使用し、実データから抽出したパラメータで新しいDICOMを生成。
+- 生成されたDICOMを DICOM チェッカーでスキャンし、エラーがないことを確認。
+- 線量分布などの幾何学的整合性を確認。

--- a/rt_dicom_toolkit/__main__.py
+++ b/rt_dicom_toolkit/__main__.py
@@ -15,10 +15,13 @@ def main():
         run_app()
     else:
         # 引数がある場合はCLIへ委譲
-        from .cli import run_anonymizer_cli, run_validator_cli
+        from .cli import run_anonymizer_cli, run_validator_cli, run_template_cli
         if sys.argv[1] == 'validate':
             sys.argv.pop(1)
             run_validator_cli()
+        elif sys.argv[1] == 'template':
+            # run_template_cli()内でsys.argv[2:]をパースする
+            run_template_cli()
         else:
             run_anonymizer_cli()
 

--- a/rt_dicom_toolkit/cli.py
+++ b/rt_dicom_toolkit/cli.py
@@ -58,9 +58,58 @@ def run_validator_cli():
     
     validator.validate_files(validator.original_dir, validator.anonymized_dir)
 
+def run_template_cli():
+    """テンプレート適用のCLIエントリーポイント"""
+    parser = argparse.ArgumentParser(description='RT DICOMテンプレート合成ツール')
+    parser.add_argument('--template', required=True, help='テンプレートDICOMファイルのパス')
+    parser.add_argument('--input', help='情報抽出元のDICOMディレクトリまたはファイル', default=str(DEFAULT_INPUT_DIR))
+    parser.add_argument('--output', help='出力ディレクトリのパス', default=str(DEFAULT_ANONYMOUS_DIR))
+    parser.add_argument('--no-patient', action='store_true', help='患者情報を同期しない')
+    parser.add_argument('--no-geometry', action='store_true', help='幾何学情報を同期しない')
+    args = parser.parse_args(sys.argv[2:])
+    
+    from .template.engine import DICOMTemplateEngine
+    from .utils.file_utils import find_dicom_files
+    
+    engine = DICOMTemplateEngine(args.template)
+    input_path = Path(args.input)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    sync_patient = not args.no_patient
+    sync_geometry = not args.no_geometry
+    
+    if input_path.is_file():
+        files = [input_path]
+    else:
+        files = find_dicom_files(input_path)
+        
+    print(f"テンプレート: {args.template}")
+    print(f"抽出元: {input_path} ({len(files)} ファイル)")
+    print(f"出力先: {output_dir}")
+    
+    for file_path in files:
+        try:
+            synced_dcm = engine.sync_from_source(
+                str(file_path), 
+                sync_patient=sync_patient, 
+                sync_geometry=sync_geometry
+            )
+            output_path = output_dir / f"tmpl_{file_path.name}"
+            synced_dcm.save_as(str(output_path), write_like_original=False)
+            print(f"  成功: {file_path.name} -> {output_path.name}")
+        except Exception as e:
+            print(f"  エラー ({file_path.name}): {e}")
+
 if __name__ == '__main__':
-    if len(sys.argv) > 1 and sys.argv[1] == 'validate':
-        sys.argv.pop(1)  # 'validate' 引数を削除
-        run_validator_cli()
+    if len(sys.argv) > 1:
+        if sys.argv[1] == 'validate':
+            sys.argv.pop(1)  # 'validate' 引数を削除
+            run_validator_cli()
+        elif sys.argv[1] == 'template':
+            # run_template_cli() 内で parse_args(sys.argv[2:]) を行うためここではpopしない
+            run_template_cli()
+        else:
+            run_anonymizer_cli()
     else:
         run_anonymizer_cli()

--- a/rt_dicom_toolkit/gui/template_gui.py
+++ b/rt_dicom_toolkit/gui/template_gui.py
@@ -1,0 +1,218 @@
+import os
+import threading
+from pathlib import Path
+import customtkinter as ctk
+from tkinter import filedialog, messagebox
+
+from rt_dicom_toolkit.template.engine import DICOMTemplateEngine
+from rt_dicom_toolkit.utils.file_utils import find_dicom_files
+
+class TemplateApp(ctk.CTk):
+    def __init__(self):
+        super().__init__()
+
+        self.title("RT DICOM Template Engine")
+        self.geometry("800x600")
+        self.minsize(700, 500)
+        
+        ctk.set_appearance_mode("system")
+        ctk.set_default_color_theme("blue")
+        
+        self._build_ui()
+        
+    def _build_ui(self):
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(1, weight=1)
+        
+        # --- 設定パネル ---
+        self.settings_frame = ctk.CTkFrame(self)
+        self.settings_frame.grid(row=0, column=0, padx=20, pady=20, sticky="ew")
+        self.settings_frame.grid_columnconfigure(1, weight=1)
+        
+        # テンプレートファイル
+        self.template_label = ctk.CTkLabel(self.settings_frame, text="テンプレートDICOM:")
+        self.template_label.grid(row=0, column=0, padx=10, pady=10, sticky="w")
+        
+        self.template_entry = ctk.CTkEntry(self.settings_frame)
+        self.template_entry.grid(row=0, column=1, padx=10, pady=10, sticky="ew")
+        
+        self.template_btn = ctk.CTkButton(self.settings_frame, text="参照", width=80, command=self._browse_template)
+        self.template_btn.grid(row=0, column=2, padx=10, pady=10)
+        
+        # 入力ディレクトリ
+        self.input_label = ctk.CTkLabel(self.settings_frame, text="情報抽出元 (Dir/File):")
+        self.input_label.grid(row=1, column=0, padx=10, pady=10, sticky="w")
+        
+        self.input_entry = ctk.CTkEntry(self.settings_frame)
+        self.input_entry.grid(row=1, column=1, padx=10, pady=10, sticky="ew")
+        
+        self.input_btn = ctk.CTkButton(self.settings_frame, text="参照", width=80, command=self._browse_input)
+        self.input_btn.grid(row=1, column=2, padx=10, pady=10)
+        
+        # 出力ディレクトリ
+        self.output_label = ctk.CTkLabel(self.settings_frame, text="出力ディレクトリ:")
+        self.output_label.grid(row=2, column=0, padx=10, pady=10, sticky="w")
+        
+        self.output_entry = ctk.CTkEntry(self.settings_frame)
+        self.output_entry.grid(row=2, column=1, padx=10, pady=10, sticky="ew")
+        
+        self.output_btn = ctk.CTkButton(self.settings_frame, text="参照", width=80, command=self._browse_output)
+        self.output_btn.grid(row=2, column=2, padx=10, pady=10)
+        
+        # オプション設定
+        self.options_frame = ctk.CTkFrame(self.settings_frame, fg_color="transparent")
+        self.options_frame.grid(row=3, column=0, columnspan=3, padx=10, pady=5, sticky="ew")
+        
+        self.sync_patient_var = ctk.BooleanVar(value=True)
+        self.sync_patient_cb = ctk.CTkCheckBox(self.options_frame, text="患者情報を同期", variable=self.sync_patient_var)
+        self.sync_patient_cb.grid(row=0, column=0, padx=20, pady=5)
+        
+        self.sync_geometry_var = ctk.BooleanVar(value=True)
+        self.sync_geometry_cb = ctk.CTkCheckBox(self.options_frame, text="幾何学情報を同期", variable=self.sync_geometry_var)
+        self.sync_geometry_cb.grid(row=0, column=1, padx=20, pady=5)
+        
+        # --- ログ表示パネル ---
+        self.log_frame = ctk.CTkFrame(self)
+        self.log_frame.grid(row=1, column=0, padx=20, pady=(0, 20), sticky="nsew")
+        self.log_frame.grid_columnconfigure(0, weight=1)
+        self.log_frame.grid_rowconfigure(0, weight=1)
+        
+        self.log_textbox = ctk.CTkTextbox(self.log_frame)
+        self.log_textbox.grid(row=0, column=0, padx=10, pady=10, sticky="nsew")
+        self.log_textbox.configure(state="disabled")
+        
+        # --- ステータス・実行パネル ---
+        self.status_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.status_frame.grid(row=2, column=0, padx=20, pady=(0, 20), sticky="ew")
+        self.status_frame.grid_columnconfigure(0, weight=1)
+        
+        self.status_label = ctk.CTkLabel(self.status_frame, text="待機中...")
+        self.status_label.grid(row=0, column=0, sticky="w", padx=5)
+        
+        self.progress_bar = ctk.CTkProgressBar(self.status_frame)
+        self.progress_bar.grid(row=1, column=0, sticky="ew", padx=5, pady=(5, 10))
+        self.progress_bar.set(0)
+        
+        self.run_btn = ctk.CTkButton(self.status_frame, text="合成を開始", height=40, font=("", 16, "bold"), command=self._start_processing)
+        self.run_btn.grid(row=1, column=1, padx=(10, 5), pady=(5, 10))
+
+    def _browse_template(self):
+        path = filedialog.askopenfilename(title="テンプレートDICOMの選択", filetypes=[("DICOM Files", "*.dcm"), ("All Files", "*.*")])
+        if path:
+            self.template_entry.delete(0, 'end')
+            self.template_entry.insert(0, path)
+
+    def _browse_input(self):
+        path = filedialog.askdirectory(title="情報抽出元ディレクトリの選択")
+        if path:
+            self.input_entry.delete(0, 'end')
+            self.input_entry.insert(0, path)
+
+    def _browse_output(self):
+        path = filedialog.askdirectory(title="出力ディレクトリの選択")
+        if path:
+            self.output_entry.delete(0, 'end')
+            self.output_entry.insert(0, path)
+            
+    def _append_log(self, message):
+        def update_text():
+            self.log_textbox.configure(state="normal")
+            self.log_textbox.insert("end", message + "\n")
+            self.log_textbox.see("end")
+            self.log_textbox.configure(state="disabled")
+        self.after(0, update_text)
+        
+    def _update_progress(self, current, total, filename):
+        def update():
+            progress = current / total if total > 0 else 0
+            self.progress_bar.set(progress)
+            self.status_label.configure(text=f"処理中... {current}/{total} ({progress*100:.1f}%) : {filename}")
+        self.after(0, update)
+        
+    def _processing_finished(self, success, message=""):
+        def update():
+            self.run_btn.configure(state="normal", text="合成を開始")
+            self.status_label.configure(text="完了" if success else f"エラー: {message}")
+            if success:
+                messagebox.showinfo("完了", "テンプレート合成が完了しました。")
+            else:
+                messagebox.showerror("エラー", f"処理中にエラーが発生しました:\n{message}")
+        self.after(0, update)
+
+    def _start_processing(self):
+        tmpl_path = self.template_entry.get()
+        in_path = self.input_entry.get()
+        out_path = self.output_entry.get()
+        
+        if not os.path.exists(tmpl_path) or not os.path.isfile(tmpl_path):
+            messagebox.showerror("エラー", "有効なテンプレートファイルを選択してください。")
+            return
+            
+        if not in_path or not os.path.exists(in_path):
+            messagebox.showerror("エラー", "有効な入力ディレクトリ/ファイルを選択してください。")
+            return
+            
+        if not out_path:
+            messagebox.showerror("エラー", "出力ディレクトリを選択してください。")
+            return
+            
+        self.run_btn.configure(state="disabled", text="処理中...")
+        self.progress_bar.set(0)
+        self.status_label.configure(text="処理を準備中...")
+        self.log_textbox.configure(state="normal")
+        self.log_textbox.delete("1.0", "end")
+        self.log_textbox.configure(state="disabled")
+        
+        threading.Thread(target=self._run_process_thread, args=(tmpl_path, in_path, out_path), daemon=True).start()
+        
+    def _run_process_thread(self, tmpl_path, in_path, out_path):
+        try:
+            self._append_log(f"テンプレート読み込み中: {tmpl_path}")
+            engine = DICOMTemplateEngine(tmpl_path)
+            
+            input_path = Path(in_path)
+            output_dir = Path(out_path)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            
+            sync_patient = self.sync_patient_var.get()
+            sync_geometry = self.sync_geometry_var.get()
+            
+            if input_path.is_file():
+                files = [input_path]
+            else:
+                files = find_dicom_files(input_path)
+                
+            total = len(files)
+            if total == 0:
+                self._append_log("処理対象のファイルが見つかりません。")
+                self._processing_finished(True)
+                return
+                
+            for i, file_path in enumerate(files):
+                self._update_progress(i + 1, total, file_path.name)
+                self._append_log(f"処理中: {file_path.name}")
+                
+                try:
+                    synced_dcm = engine.sync_from_source(
+                        str(file_path), 
+                        sync_patient=sync_patient, 
+                        sync_geometry=sync_geometry
+                    )
+                    output_path = output_dir / f"tmpl_{file_path.name}"
+                    synced_dcm.save_as(str(output_path), write_like_original=False)
+                    self._append_log(f"  成功: -> {output_path.name}")
+                except Exception as e:
+                    self._append_log(f"  エラー: {e}")
+                    
+            self._append_log("すべての処理が完了しました。")
+            self._processing_finished(True)
+        except Exception as e:
+            self._append_log(f"致命的なエラー: {str(e)}")
+            self._processing_finished(False, str(e))
+
+def run_template_app():
+    app = TemplateApp()
+    app.mainloop()
+
+if __name__ == "__main__":
+    run_template_app()

--- a/rt_dicom_toolkit/template/__init__.py
+++ b/rt_dicom_toolkit/template/__init__.py
@@ -1,0 +1,9 @@
+from .engine import DICOMTemplateEngine
+from .tags import PATIENT_TAGS, GEOMETRY_TAGS, RT_SPECIFIC_TAGS
+
+__all__ = [
+    "DICOMTemplateEngine",
+    "PATIENT_TAGS",
+    "GEOMETRY_TAGS",
+    "RT_SPECIFIC_TAGS"
+]

--- a/rt_dicom_toolkit/template/engine.py
+++ b/rt_dicom_toolkit/template/engine.py
@@ -1,0 +1,88 @@
+"""
+DICOMテンプレートエンジン
+"""
+import copy
+import logging
+from typing import Dict, Any, Optional
+
+import pydicom
+from pydicom.uid import generate_uid
+
+from .tags import PATIENT_TAGS, GEOMETRY_TAGS, RT_SPECIFIC_TAGS
+
+logger = logging.getLogger(__name__)
+
+class DICOMTemplateEngine:
+    """
+    テンプレートとなるDICOMファイルに、別のDICOMファイルから情報を抽出・合成するクラス
+    """
+    
+    def __init__(self, template_path: str):
+        """
+        Args:
+            template_path: テンプレートとなるDICOMファイルのパス
+        """
+        self.template_path = template_path
+        # force=True で読み込み、未知のタグや不完全なメタデータにも対応
+        self._template_dcm = pydicom.dcmread(template_path, force=True)
+        
+    def get_template_copy(self) -> pydicom.dataset.FileDataset:
+        """テンプレートのディープコピーを返す"""
+        return copy.deepcopy(self._template_dcm)
+        
+    def sync_from_source(self, source_dcm_path: str, 
+                         sync_patient: bool = True, 
+                         sync_geometry: bool = True,
+                         sync_rt_specific: bool = True) -> pydicom.dataset.FileDataset:
+        """
+        元のDICOMファイルから情報を抽出し、テンプレートに合成して新しいデータセットを返す
+        
+        Args:
+            source_dcm_path: 情報の抽出元となるDICOMファイルのパス
+            sync_patient: 患者情報を同期するか
+            sync_geometry: 幾何学情報を同期するか
+            sync_rt_specific: RT系特有の情報を同期するか
+            
+        Returns:
+            合成済みの新しいDICOMデータセット
+        """
+        source_dcm = pydicom.dcmread(source_dcm_path, force=True)
+        target_dcm = self.get_template_copy()
+        
+        tags_to_sync = []
+        if sync_patient:
+            tags_to_sync.extend(PATIENT_TAGS)
+        if sync_geometry:
+            tags_to_sync.extend(GEOMETRY_TAGS)
+        if sync_rt_specific:
+            tags_to_sync.extend(RT_SPECIFIC_TAGS)
+            
+        # タグのコピー
+        self._copy_tags(source_dcm, target_dcm, tags_to_sync)
+        
+        # モダリティ不一致の警告
+        if hasattr(source_dcm, 'Modality') and hasattr(target_dcm, 'Modality'):
+            if source_dcm.Modality != target_dcm.Modality:
+                logger.warning(f"Modality mismatch. Source: {source_dcm.Modality}, Template: {target_dcm.Modality}")
+                
+        # テンプレート化＝新しいインスタンス生成なので、UIDを更新
+        target_dcm.SOPInstanceUID = generate_uid()
+        # シリーズをまとめるか分けるかは要件によるが、今回は独立したファイルとして扱うためSeriesInstanceUIDも更新
+        target_dcm.SeriesInstanceUID = generate_uid()
+        
+        if hasattr(target_dcm, 'file_meta') and target_dcm.file_meta is not None:
+            target_dcm.file_meta.MediaStorageSOPInstanceUID = target_dcm.SOPInstanceUID
+            
+        return target_dcm
+        
+    def _copy_tags(self, source: pydicom.dataset.Dataset, target: pydicom.dataset.Dataset, tag_names: list):
+        """指定されたタグのリストをsourceからtargetへコピーする"""
+        copied_count = 0
+        for tag_name in tag_names:
+            if hasattr(source, tag_name):
+                value = getattr(source, tag_name)
+                # target に上書き（または新規追加）
+                setattr(target, tag_name, value)
+                copied_count += 1
+        logger.debug(f"{copied_count} 個のタグを同期しました。")
+

--- a/rt_dicom_toolkit/template/tags.py
+++ b/rt_dicom_toolkit/template/tags.py
@@ -1,0 +1,38 @@
+"""
+DICOMテンプレート同期に使用するタグ定義
+"""
+
+# 患者・検査情報（基本的な識別子）
+PATIENT_TAGS = [
+    "PatientName",
+    "PatientID",
+    "PatientBirthDate",
+    "PatientSex",
+    "StudyInstanceUID",
+    "StudyID",
+    "StudyDate",
+    "StudyTime",
+    "AccessionNumber",
+]
+
+# 幾何学的・画像情報（座標や解像度）
+GEOMETRY_TAGS = [
+    "ImagePositionPatient",
+    "ImageOrientationPatient",
+    "PixelSpacing",
+    "SliceThickness",
+    "Rows",
+    "Columns",
+    "FrameOfReferenceUID",
+    "PositionReferenceIndicator",
+    "NumberOfFrames",
+]
+
+# RTDOSEなどに特有のタグ（必要に応じて同期）
+RT_SPECIFIC_TAGS = [
+    "GridFrameOffsetVector",
+    "DoseGridScaling",
+    "DoseSummationType",
+    "DoseType",
+    "DoseUnits",
+]

--- a/start_template_gui.bat
+++ b/start_template_gui.bat
@@ -1,0 +1,5 @@
+@echo off
+set PYTHONUTF8=1
+set PYTHONPATH=%~dp0
+python -m rt_dicom_toolkit.gui.template_gui
+pause

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -1,0 +1,85 @@
+import os
+import pytest
+import pydicom
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
+
+from rt_dicom_toolkit.template import DICOMTemplateEngine
+
+@pytest.fixture
+def mock_dicom_files(tmp_path):
+    """テスト用のモックDICOMファイルを生成する"""
+    # テンプレートファイル
+    template_path = tmp_path / "template.dcm"
+    template_dcm = FileDataset(str(template_path), {}, file_meta=FileMetaDataset())
+    template_dcm.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    template_dcm.file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.481.2" # RT DOSE
+    template_dcm.file_meta.MediaStorageSOPInstanceUID = generate_uid()
+    template_dcm.is_little_endian = True
+    template_dcm.is_implicit_VR = False
+    
+    template_dcm.Modality = "RTDOSE"
+    template_dcm.PatientName = "TEMPLATE^PATIENT"
+    template_dcm.PatientID = "TMPL001"
+    template_dcm.ImagePositionPatient = [0, 0, 0]
+    template_dcm.PixelSpacing = [1.0, 1.0]
+    template_dcm.SOPInstanceUID = template_dcm.file_meta.MediaStorageSOPInstanceUID
+    template_dcm.save_as(str(template_path), write_like_original=False)
+    
+    # ソースファイル
+    source_path = tmp_path / "source.dcm"
+    source_dcm = FileDataset(str(source_path), {}, file_meta=FileMetaDataset())
+    source_dcm.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    source_dcm.file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.481.2"
+    source_dcm.file_meta.MediaStorageSOPInstanceUID = generate_uid()
+    source_dcm.is_little_endian = True
+    source_dcm.is_implicit_VR = False
+    
+    source_dcm.Modality = "RTDOSE"
+    source_dcm.PatientName = "REAL^PATIENT"
+    source_dcm.PatientID = "REAL123"
+    source_dcm.ImagePositionPatient = [-100.5, -50.0, 25.5]
+    source_dcm.PixelSpacing = [2.5, 2.5]
+    source_dcm.SOPInstanceUID = source_dcm.file_meta.MediaStorageSOPInstanceUID
+    source_dcm.save_as(str(source_path), write_like_original=False)
+    
+    return str(template_path), str(source_path)
+
+def test_template_engine_init(mock_dicom_files):
+    template_path, _ = mock_dicom_files
+    engine = DICOMTemplateEngine(template_path)
+    
+    assert engine.template_path == template_path
+    assert engine._template_dcm.PatientID == "TMPL001"
+
+def test_sync_from_source(mock_dicom_files):
+    template_path, source_path = mock_dicom_files
+    engine = DICOMTemplateEngine(template_path)
+    
+    # 同期実行
+    synced_dcm = engine.sync_from_source(source_path)
+    
+    # 患者情報がソースから同期されているか
+    assert synced_dcm.PatientName == "REAL^PATIENT"
+    assert synced_dcm.PatientID == "REAL123"
+    
+    # 幾何学情報がソースから同期されているか
+    assert synced_dcm.ImagePositionPatient == [-100.5, -50.0, 25.5]
+    assert synced_dcm.PixelSpacing == [2.5, 2.5]
+    
+    # 新しいUIDが生成されているか
+    assert synced_dcm.SOPInstanceUID != engine._template_dcm.SOPInstanceUID
+    assert synced_dcm.file_meta.MediaStorageSOPInstanceUID == synced_dcm.SOPInstanceUID
+    
+def test_sync_partial(mock_dicom_files):
+    template_path, source_path = mock_dicom_files
+    engine = DICOMTemplateEngine(template_path)
+    
+    # 幾何学情報のみ同期
+    synced_dcm = engine.sync_from_source(source_path, sync_patient=False)
+    
+    # 患者情報はテンプレートのまま
+    assert synced_dcm.PatientID == "TMPL001"
+    
+    # 幾何学情報はソースのもの
+    assert synced_dcm.PixelSpacing == [2.5, 2.5]

--- a/todo.md
+++ b/todo.md
@@ -8,8 +8,6 @@
 - [x] GitHubリポジトリへの登録とREADMEの更新
 
 ## 次の目標
-- [x] DICOM匿名化チェッカー (CLI & GUI) の実装 (OpenSpec: 002_anonymization_checker)
-- [x] 内部UID参照（Referenced SOP Instance UID等）の一貫性保持機能の実装
-- [ ] Universal DICOM Template の実装（PHITS-to-DICOMパイプラインの安定化）
+- [ ] Universal DICOM Template の実装（PHITS-to-DICOMパイプラインの安定化） (OpenSpec: 004_universal_template)
 - [ ] 検証スクリプトの詳細化
 - [ ] PyInstallerによる実行ファイル化の検討


### PR DESCRIPTION
# Proposal: 004 Universal DICOM Template の実装

- Status: ✅ APPROVED
- Author: Antigravity
- Date: 2026-04-30

## 1. 背景 / 目的

### 現状の問題
PHITSからDICOM（RTDOSE等）へ変換する際、ベースとなる臨床DICOMファイル（原本）の構造がメーカーや出力設定によって異なり、変換スクリプトが特定のタグ構成に依存している場合にエラーが発生したり、出力されたDICOMがビューアで正しく表示されなかったりすることがあります。

### 解決策
「Universal Template」戦略を採用します。これは、あらかじめ用意した「標準的でクリーンなDICOMファイル（テンプレート）」をベースとし、そこに原本DICOMから抽出した特定の幾何学的パラメータ（座標、解像度等）や患者情報を注入して新しいDICOMを生成する手法です。これにより、出力ファイルの構造が常に一定に保たれ、システムの安定性が向上します。

## 2. 変更内容

### 2.1 新規モジュール `rt_dicom_toolkit/template/`
- **`engine.py`**: テンプレート操作の中核ロジック。
  - `DICOMTemplateEngine` クラスを実装。
  - `inject_tags(template_path, source_tags_dict)`: タグの注入。
  - `sync_geometry(template_path, source_dicom_path)`: 幾何学情報の同期。
- **`tags.py`**: 同期すべき標準タグリストの定義。
  - `GEOMETRY_TAGS`: `ImagePositionPatient`, `PixelSpacing`, `Rows`, `Columns` 等。
  - `PATIENT_TAGS`: `PatientName`, `PatientID`, `StudyInstanceUID` 等。

### 2.2 CLIの拡張 (`rt_dicom_toolkit/cli.py`)
- `--template` オプションの追加。
- `template-base` コマンド（または既存コマンドのサブオプション）の実装。

### 2.3 GUIの拡張 (`rt_dicom_toolkit/gui/`)
- テンプレートファイルを選択するUI要素の追加。

## 3. 影響範囲 / リスク
- **既存の匿名化機能**: 影響なし。本機能は独立したツール/モードとして提供。
- **モダリティ不一致**: テンプレート（例: CT）と原本（例: RTDOSE）のモダリティが異なる場合、手動でのタグ調整が必要になる可能性がある。初期実装では警告を出す。

## 4. テスト・検証計画

### 4.1 ユニットテスト
- テンプレートファイルに特定の値が正しく注入されることを確認。
- 幾何学情報（座標・間隔）が原本と一致するように更新されることを確認。

### 4.2 統合テスト
- `DICOM/sample.dcm` をテンプレートとして使用し、実データから抽出したパラメータで新しいDICOMを生成。
- 生成されたDICOMを DICOM チェッカーでスキャンし、エラーがないことを確認。
- 線量分布などの幾何学的整合性を確認。
