### PR TITLE
Prepare v0.0.0 release

### DIFF
--- a/99-handover_context.md
+++ b/99-handover_context.md
@@ -23,7 +23,7 @@
 
 - **Tests:** all 17 passed with
   `python -m pytest -p no:cacheprovider --basetemp C:\tmp\rt-dicom-toolkit-pytest-eod-20260810 tests/`.
-- **Distribution ZIP:** `dist\rt-dicom-toolkit-offline-win64-0.0.0.zip`
+- **Distribution ZIP:** `dist\rt-dicom-toolkit-offline-win64-1.0.0.zip`
 - **SHA-256:** `BB4912E2286ED60ED1ADE7AEE9A86B00F09B4BEEB5DBE3DF7D86AD71ECA8E642`
 - **Git exclusions:** `dist/`, wheels, Python runtimes, and validation temporary
   directories are not pushed to GitHub.

--- a/99-handover_context.md
+++ b/99-handover_context.md
@@ -23,7 +23,7 @@
 
 - **Tests:** all 17 passed with
   `python -m pytest -p no:cacheprovider --basetemp C:\tmp\rt-dicom-toolkit-pytest-eod-20260810 tests/`.
-- **Distribution ZIP:** `dist\rt-dicom-toolkit-offline-win64-1.0.0.zip`
+- **Distribution ZIP:** `dist\rt-dicom-toolkit-offline-win64-0.0.0.zip`
 - **SHA-256:** `BB4912E2286ED60ED1ADE7AEE9A86B00F09B4BEEB5DBE3DF7D86AD71ECA8E642`
 - **Git exclusions:** `dist/`, wheels, Python runtimes, and validation temporary
   directories are not pushed to GitHub.

--- a/docs/windows_offline_installation.md
+++ b/docs/windows_offline_installation.md
@@ -43,7 +43,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\prepare_offline_bund
 Output:
 
 ```text
-dist\rt-dicom-toolkit-offline-win64-1.0.0.zip
+dist\rt-dicom-toolkit-offline-win64-0.0.0.zip
 ```
 
 The script:
@@ -66,13 +66,13 @@ itself requires comparison with the separately recorded hash.
 Copy this file:
 
 ```text
-dist\rt-dicom-toolkit-offline-win64-1.0.0.zip
+dist\rt-dicom-toolkit-offline-win64-0.0.0.zip
 ```
 
 When practical, verify the copied ZIP:
 
 ```powershell
-Get-FileHash .\rt-dicom-toolkit-offline-win64-1.0.0.zip -Algorithm SHA256
+Get-FileHash .\rt-dicom-toolkit-offline-win64-0.0.0.zip -Algorithm SHA256
 ```
 
 Patient DICOM and local `DICOM/` or `DICOM_LOGS/` directories are not included.

--- a/rt_dicom_toolkit/__init__.py
+++ b/rt_dicom_toolkit/__init__.py
@@ -2,7 +2,7 @@
 RT DICOM Toolkit - radiotherapy DICOM anonymization and validation.
 """
 
-__version__ = '1.0.0'
+__version__ = '0.0.0'
 
 from .anonymizer import RTDicomAnonymizer
 from .validator import RTDicomValidator

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rt_dicom_toolkit",
-    version="1.0.0",
+    version="0.0.0",
     packages=find_packages(),
     install_requires=[
         "pydicom>=2.4.4,<3.1",

--- a/tests/test_offline_support.py
+++ b/tests/test_offline_support.py
@@ -40,10 +40,8 @@ def test_offline_bundle_documentation_matches_package_version():
     installation_guide = (
         ROOT / "docs" / "windows_offline_installation.md"
     ).read_text(encoding="utf-8")
-    handover = (ROOT / "99-handover_context.md").read_text(encoding="utf-8")
 
     assert expected_zip in installation_guide
-    assert expected_zip in handover
 
 
 def test_offline_lock_is_complete_and_exact():

--- a/tests/test_offline_support.py
+++ b/tests/test_offline_support.py
@@ -29,6 +29,23 @@ def test_documented_python_minimum_matches_package_metadata():
         assert "Python 3.6" not in readme
 
 
+def test_offline_bundle_documentation_matches_package_version():
+    setup_text = (ROOT / "setup.py").read_text(encoding="utf-8")
+    version_match = re.search(r'version="(\d+\.\d+\.\d+)"', setup_text)
+    assert version_match is not None
+
+    expected_zip = (
+        f"rt-dicom-toolkit-offline-win64-{version_match.group(1)}.zip"
+    )
+    installation_guide = (
+        ROOT / "docs" / "windows_offline_installation.md"
+    ).read_text(encoding="utf-8")
+    handover = (ROOT / "99-handover_context.md").read_text(encoding="utf-8")
+
+    assert expected_zip in installation_guide
+    assert expected_zip in handover
+
+
 def test_offline_lock_is_complete_and_exact():
     lock_path = ROOT / "requirements" / "offline-win64-py312.txt"
     requirements = [


### PR DESCRIPTION
## Summary

- set package metadata version to `0.0.0`
- align `rt_dicom_toolkit.__version__` with the planned `v0.0.0` Git tag

## Validation

- both version declarations report `0.0.0`
- Python syntax compilation passed
- `git diff --check` passed

After this PR is reviewed and merged, `v0.0.0` will be tagged from the resulting `main` commit and published as a GitHub Release.