### PR TITLE
Document offline install, launch, and removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To uninstall the offline toolkit:
 1. Close every RT DICOM Toolkit window.
 2. Move any files that must be retained out of the extracted `data` directory.
 3. Check whether `.runtime\python.exe` exists in the extracted folder. If it
-   does, open **Windows Settings > Apps > Installed apps** and uninstall the
+   does, open **Windows Settings > Apps > Apps & features** and uninstall the
    **Python 3.12.10 (64-bit)** entry that was installed with this bundle. Do not
    remove an existing Python installation when the bundle has no `.runtime`.
 4. Delete only the verified extracted bundle folder. This removes the toolkit,

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ for a normal installation.
    `rt-dicom-toolkit-offline-win64-<version>.zip` from
    [GitHub Releases](https://github.com/inata169/rt-dicom-toolkit/releases).
 2. Verify the ZIP's SHA-256 value against the checksum in its release notes.
-3. Copy the ZIP to the offline Windows 10/11 x64 computer.
+3. Copy the ZIP to the offline Windows 10 x64 computer.
 4. Extract it to a writable local folder. Do not run the installer directly
    from the ZIP or extract and install it on USB media.
 5. Double-click `install_offline.bat`. It verifies the bundled files, creates a

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ for a normal installation.
    `rt-dicom-toolkit-offline-win64-<version>.zip` from
    [GitHub Releases](https://github.com/inata169/rt-dicom-toolkit/releases).
 2. Verify the ZIP's SHA-256 value against the checksum in its release notes.
-3. Copy the ZIP to the offline Windows 10 x64 computer.
+3. Copy the ZIP to the offline Windows 10/11 x64 computer.
 4. Extract it to a writable local folder. Do not run the installer directly
    from the ZIP or extract and install it on USB media.
 5. Double-click `install_offline.bat`. It verifies the bundled files, creates a
@@ -111,9 +111,10 @@ To uninstall the offline toolkit:
 1. Close every RT DICOM Toolkit window.
 2. Move any files that must be retained out of the extracted `data` directory.
 3. Check whether `.runtime\python.exe` exists in the extracted folder. If it
-   does, open **Windows Settings > Apps > Apps & features** and uninstall the
-   **Python 3.12.10 (64-bit)** entry that was installed with this bundle. Do not
-   remove an existing Python installation when the bundle has no `.runtime`.
+   does, open **Windows Settings > Apps > Apps & features** on Windows 10 or
+   **Windows Settings > Apps > Installed apps** on Windows 11, then uninstall
+   the **Python 3.12.10 (64-bit)** entry that was installed with this bundle. Do
+   not remove an existing Python installation when the bundle has no `.runtime`.
 4. Delete only the verified extracted bundle folder. This removes the toolkit,
    its dedicated virtual environment, and the remaining bundled files.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ for a normal installation.
 2. Verify the ZIP's SHA-256 value against the checksum in its release notes.
 3. Copy the ZIP to the offline Windows 10/11 x64 computer.
 4. Extract it to a writable local folder. Do not run the installer directly
-   from the ZIP or from read-only USB media.
+   from the ZIP or extract and install it on USB media.
 5. Double-click `install_offline.bat`. It verifies the bundled files, creates a
    dedicated `.venv`, installs only from the bundled wheels, and runs a
    synthetic-DICOM smoke test.
@@ -110,8 +110,12 @@ To uninstall the offline toolkit:
 
 1. Close every RT DICOM Toolkit window.
 2. Move any files that must be retained out of the extracted `data` directory.
-3. Delete only the verified extracted bundle folder. This removes the dedicated
-   virtual environment and any private Python runtime installed inside it.
+3. Check whether `.runtime\python.exe` exists in the extracted folder. If it
+   does, open **Windows Settings > Apps > Installed apps** and uninstall the
+   **Python 3.12.10 (64-bit)** entry that was installed with this bundle. Do not
+   remove an existing Python installation when the bundle has no `.runtime`.
+4. Delete only the verified extracted bundle folder. This removes the toolkit,
+   its dedicated virtual environment, and the remaining bundled files.
 
 The installer does not add the toolkit to `PATH`, create shortcuts, or register
 file associations. Output directories selected outside the extracted bundle,

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ To uninstall the offline toolkit:
 
 The installer does not add the toolkit to `PATH`, create shortcuts, or register
 file associations. Output directories selected outside the extracted bundle,
-such as `D:\DICOM_OUTPUT`, are not removed during uninstallation.
+such as a user-selected external output directory, are not removed during
+uninstallation.
 
 For checksum commands, reinstall instructions, troubleshooting, and the full
 offline procedure, see the

--- a/README.md
+++ b/README.md
@@ -85,8 +85,41 @@ python -m pip install -r rt_dicom_toolkit/requirements.txt
 python -m pip install -e .
 ```
 
-For a network-isolated Windows installation, see
-[`docs/windows_offline_installation.md`](docs/windows_offline_installation.md).
+### Offline installation on Windows
+
+The offline bundle is self-contained and does not require administrator access
+for a normal installation.
+
+1. On an internet-connected computer, download
+   `rt-dicom-toolkit-offline-win64-<version>.zip` from
+   [GitHub Releases](https://github.com/inata169/rt-dicom-toolkit/releases).
+2. Verify the ZIP's SHA-256 value against the checksum in its release notes.
+3. Copy the ZIP to the offline Windows 10/11 x64 computer.
+4. Extract it to a writable local folder. Do not run the installer directly
+   from the ZIP or from read-only USB media.
+5. Double-click `install_offline.bat`. It verifies the bundled files, creates a
+   dedicated `.venv`, installs only from the bundled wheels, and runs a
+   synthetic-DICOM smoke test.
+
+To start the installed toolkit, double-click
+`start_rt_dicom_toolkit.bat` in the extracted folder. Keep that folder in
+place while using the application. Its `data` directory contains the default
+input, output, log, and report locations.
+
+To uninstall the offline toolkit:
+
+1. Close every RT DICOM Toolkit window.
+2. Move any files that must be retained out of the extracted `data` directory.
+3. Delete only the verified extracted bundle folder. This removes the dedicated
+   virtual environment and any private Python runtime installed inside it.
+
+The installer does not add the toolkit to `PATH`, create shortcuts, or register
+file associations. Output directories selected outside the extracted bundle,
+such as `D:\DICOM_OUTPUT`, are not removed during uninstallation.
+
+For checksum commands, reinstall instructions, troubleshooting, and the full
+offline procedure, see the
+[Windows offline installation guide](docs/windows_offline_installation.md).
 
 ## Testing
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,7 +11,10 @@ Additional documentation:
 - [`windows_offline_installation.md`](windows_offline_installation.md): build
   and use the Windows x64 offline bundle;
 - [`windows_offline_installation_validation_2026-08-10.md`](windows_offline_installation_validation_2026-08-10.md):
-  recorded validation of the offline workflow.
+  recorded Windows 10 validation of the offline workflow;
+- [`windows_offline_installation_validation_2026-08-21.md`](windows_offline_installation_validation_2026-08-21.md):
+  recorded human-observed Windows 11 installation, launch, and anonymizer
+  validation for release `v0.0.0`.
 
 Development and safety guidance:
 

--- a/docs/windows_offline_installation.md
+++ b/docs/windows_offline_installation.md
@@ -173,6 +173,15 @@ directory's `data`. If that destination already exists, it is moved to
 `data\legacy-venv-data`. If the backup destination also exists, installation
 stops instead of deleting data.
 
-For a completely clean reinstall, first move the extracted `data` directory to
-an approved secure location. Then remove only the verified extracted bundle
-folder and extract the original ZIP into a new local folder.
+For a completely clean reinstall or removal, first close every toolkit window
+and move the extracted `data` directory to an approved secure location if it
+must be retained. If `.runtime\python.exe` exists, the bundle installed a
+private Python runtime that is also registered with Windows. Open **Windows
+Settings > Apps > Installed apps** and uninstall the **Python 3.12.10 (64-bit)**
+entry associated with this bundle before deleting files. If `.runtime` does not
+exist, do not remove the compatible Python installation that was already on the
+computer.
+
+Finally, remove only the verified extracted bundle folder. For a reinstall,
+extract the original ZIP into a new writable local-disk folder. Output folders
+selected outside the bundle are not removed by this process.

--- a/docs/windows_offline_installation.md
+++ b/docs/windows_offline_installation.md
@@ -1,6 +1,6 @@
-# Windows 10 Offline Installation
+# Windows 10/11 Offline Installation
 
-This procedure installs RT DICOM Toolkit on a Windows 10 x64 computer without
+This procedure installs RT DICOM Toolkit on a Windows 10/11 x64 computer without
 internet access by using USB storage. Do not use patient-derived DICOM for
 installation validation. The bundled smoke test generates synthetic DICOM at
 runtime.
@@ -9,7 +9,7 @@ runtime.
 
 - Online computer: Windows 10/11 x64, PowerShell 5.1 or later, CPython 3.12 x64,
   and pip.
-- Offline computer: Windows 10 x64.
+- Offline computer: Windows 10/11 x64.
 - Bundled Python: CPython 3.12.10 x64.
 - Installation location: a dedicated `.venv` inside the locally extracted
   bundle.
@@ -177,7 +177,8 @@ For a completely clean reinstall or removal, first close every toolkit window
 and move the extracted `data` directory to an approved secure location if it
 must be retained. If `.runtime\python.exe` exists, the bundle installed a
 private Python runtime that is also registered with Windows. Open **Windows
-Settings > Apps > Apps & features** and uninstall the **Python 3.12.10 (64-bit)**
+Settings > Apps > Apps & features** on Windows 10 or **Windows Settings > Apps >
+Installed apps** on Windows 11, then uninstall the **Python 3.12.10 (64-bit)**
 entry associated with this bundle before deleting files. If `.runtime` does not
 exist, do not remove the compatible Python installation that was already on the
 computer.

--- a/docs/windows_offline_installation.md
+++ b/docs/windows_offline_installation.md
@@ -177,7 +177,7 @@ For a completely clean reinstall or removal, first close every toolkit window
 and move the extracted `data` directory to an approved secure location if it
 must be retained. If `.runtime\python.exe` exists, the bundle installed a
 private Python runtime that is also registered with Windows. Open **Windows
-Settings > Apps > Installed apps** and uninstall the **Python 3.12.10 (64-bit)**
+Settings > Apps > Apps & features** and uninstall the **Python 3.12.10 (64-bit)**
 entry associated with this bundle before deleting files. If `.runtime` does not
 exist, do not remove the compatible Python installation that was already on the
 computer.

--- a/docs/windows_offline_installation_validation_2026-08-21.md
+++ b/docs/windows_offline_installation_validation_2026-08-21.md
@@ -1,0 +1,23 @@
+# Windows 11 Offline Bundle Validation Record (2026-08-21)
+
+## Target
+
+- Repository: `inata169/rt-dicom-toolkit`
+- Release: `v0.0.0`
+- Bundle: `rt-dicom-toolkit-offline-win64-0.0.0.zip`
+- Source commit: `be7875d5b66534b9c10f7c41835df57d9b0977ac`
+- Bundle SHA-256:
+  `53d675175609e68799285292e0a2aa207d7341650dd46814a57e9dc1fe5d860c`
+- OS: Windows 11 x64, upgraded from Windows 10
+- Installation folder: `D:\Repositories\tmp`
+
+## Human-observed validation
+
+A human installed the `v0.0.0` offline bundle on the Windows 11 computer,
+started the RT DICOM Anonymizer, and completed an anonymization run. The GUI
+reported `Processing complete` and wrote the selected output, text log, and JSON
+summary under `D:\Repositories\tmp01`.
+
+This confirms the bundle installation, application launch, and anonymizer
+workflow on that Windows 11 x64 computer. It does not record a disconnected
+network test, every toolkit GUI, or the newly documented removal procedure.

--- a/docs/windows_offline_installation_validation_2026-08-21.md
+++ b/docs/windows_offline_installation_validation_2026-08-21.md
@@ -9,14 +9,14 @@
 - Bundle SHA-256:
   `53d675175609e68799285292e0a2aa207d7341650dd46814a57e9dc1fe5d860c`
 - OS: Windows 11 x64, upgraded from Windows 10
-- Installation folder: `D:\Repositories\tmp`
+- Installation location: a writable local-disk folder
 
 ## Human-observed validation
 
 A human installed the `v0.0.0` offline bundle on the Windows 11 computer,
 started the RT DICOM Anonymizer, and completed an anonymization run. The GUI
 reported `Processing complete` and wrote the selected output, text log, and JSON
-summary under `D:\Repositories\tmp01`.
+summary to a user-selected external output directory.
 
 This confirms the bundle installation, application launch, and anonymizer
 workflow on that Windows 11 x64 computer. It does not record a disconnected

--- a/docs/windows_offline_installation_validation_2026-08-21.md
+++ b/docs/windows_offline_installation_validation_2026-08-21.md
@@ -11,6 +11,43 @@
 - OS: Windows 11 x64, upgraded from Windows 10
 - Installation location: a writable local-disk folder
 
+## Artifact origins and license review
+
+- The CPython installer was downloaded by the bundle builder from
+  `https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.exe`.
+  Its Authenticode signature was valid and identified the Python Software
+  Foundation. CPython is distributed under the Python Software Foundation
+  License Version 2.
+- The 17 third-party wheels were downloaded from the official
+  `https://pypi.org/simple` index using the exact versions in
+  [`../requirements/offline-win64-py312.txt`](../requirements/offline-win64-py312.txt).
+  The license labels below were reviewed from each bundled wheel's
+  `.dist-info/LICENSE*` files and `METADATA`. Bundled third-party notices remain
+  inside the respective wheels.
+- The application wheel was built locally from the source commit recorded
+  above and is covered by the repository's [MIT License](../LICENSE).
+
+| Bundled package | Version | Reviewed license |
+|---|---:|---|
+| contourpy | 1.3.3 | BSD-3-Clause |
+| customtkinter | 5.2.2 | MIT |
+| cycler | 0.12.1 | BSD-3-Clause |
+| darkdetect | 0.8.0 | BSD-3-Clause |
+| fonttools | 4.59.0 | MIT; bundled external notices |
+| kiwisolver | 1.4.8 | BSD-3-Clause |
+| matplotlib | 3.10.3 | Matplotlib License |
+| numpy | 1.26.4 | BSD-3-Clause; bundled third-party notices |
+| packaging | 25.0 | Apache-2.0 or BSD-2-Clause |
+| pandas | 2.3.1 | BSD-3-Clause |
+| pillow | 12.0.0 | MIT-CMU |
+| pydicom | 2.4.4 | MIT |
+| pyparsing | 3.2.3 | MIT |
+| python-dateutil | 2.9.0.post0 | Apache-2.0 or BSD-3-Clause |
+| pytz | 2025.2 | MIT |
+| six | 1.17.0 | MIT |
+| tzdata | 2025.2 | Apache-2.0 |
+| rt-dicom-toolkit | 0.0.0 | MIT |
+
 ## Human-observed validation
 
 A human installed the `v0.0.0` offline bundle on the Windows 11 computer,

--- a/docs/windows_offline_installation_validation_2026-08-21.md
+++ b/docs/windows_offline_installation_validation_2026-08-21.md
@@ -50,11 +50,22 @@
 
 ## Human-observed validation
 
-A human installed the `v0.0.0` offline bundle on the Windows 11 computer,
-started the RT DICOM Anonymizer, and completed an anonymization run. The GUI
-reported `Processing complete` and wrote the selected output, text log, and JSON
-summary to a user-selected external output directory.
+A human completed `install_offline.bat` for the `v0.0.0` bundle on the Windows
+11 computer and launched the RT DICOM Anonymizer GUI. The installer reports
+success only after running the bundled
+[`offline_smoke_test.py`](../tools/offline_smoke_test.py), which creates a
+minimal project-authored synthetic CT DICOM at runtime, exercises anonymization,
+validation, and template synchronization, and removes the synthetic files at
+completion.
 
-This confirms the bundle installation, application launch, and anonymizer
-workflow on that Windows 11 x64 computer. It does not record a disconnected
-network test, every toolkit GUI, or the newly documented removal procedure.
+The human also observed a separate anonymization run reporting
+`Processing complete` and producing output, a text log, and a JSON summary.
+Because the provenance of that separately selected input was not independently
+captured in this repository, the run is recorded only as a supplementary
+observation and is not used as formal DICOM-validation evidence. No input path,
+metadata, or DICOM content from that run is recorded here.
+
+The admissible evidence therefore confirms bundle installation, the bundled
+synthetic-DICOM smoke test, and application launch on that Windows 11 x64
+computer. It does not record a disconnected network test, every toolkit GUI, or
+the newly documented removal procedure.


### PR DESCRIPTION
## Summary

- add an offline Windows install, launch, and removal quick start to `README.md`
- clarify USB restrictions, data preservation, private-runtime removal, and OS-specific Settings labels
- update the detailed guide for validated Windows 10/11 x64 use
- add the 2026-08-21 Windows 11 validation record for release `v0.0.0`
- record artifact origins and reviewed licenses for CPython, 17 dependency wheels, and the application wheel
- keep personal-machine paths and non-provenance DICOM observations out of formal evidence

## Validation

- Codex review loop passed on `216eacfbc4` with no unresolved threads
- targeted offline documentation version test passed
- Python compilation passed for referenced test and smoke-test modules
- all 18 wheel/license inventory rows matched the pinned bundle contents
- artifact-origin, local-reference, absolute-path, and synthetic-provenance checks passed
- `git diff --check` passed

## Scope

Documentation and validation evidence only. Runtime behavior, DICOM semantics, and the public specification are unchanged. No patient-derived data or metadata is included.