### PR TITLE
Use the development venv for GUI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,15 @@ legal compliance, or clinical suitability.
 
 ### Launch the GUI
 
-Double-click `start_gui.bat` from the repository root, or run:
+After completing the [development installation](#development-installation),
+double-click `start_gui.bat` from the repository root. The launcher uses only
+`.venv\Scripts\python.exe` and prints setup instructions instead of falling back
+to an unconfigured system Python.
+
+You can also run the same environment directly:
 
 ```powershell
-python -m rt_dicom_toolkit
+.\.venv\Scripts\python.exe -m rt_dicom_toolkit
 ```
 
 ### Use the command line
@@ -75,15 +80,21 @@ rt-dicom-toolkit/
 - Python 3.10 or later
 - Windows 10/11 is the primary desktop target
 
-### Install dependencies
+### Development installation
 
-For a development installation, install the dependencies declared by the
-project:
+Virtual environments are intentionally not stored in Git. After a fresh clone
+on Windows, create one and install the project into it:
 
 ```powershell
-python -m pip install -r rt_dicom_toolkit/requirements.txt
-python -m pip install -e .
+python -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip setuptools wheel
+.\.venv\Scripts\python.exe -m pip install -r .\rt_dicom_toolkit\requirements.txt
+.\.venv\Scripts\python.exe -m pip install -e .
 ```
+
+Confirm that `python --version` selects a supported Python 3.10 or later before
+creating the environment. Recreate `.venv` when changing to a different Python
+installation.
 
 ### Offline installation on Windows
 

--- a/start_gui.bat
+++ b/start_gui.bat
@@ -1,5 +1,27 @@
 @echo off
-cd /d %~dp0
-set PYTHONUTF8=1
-python -m rt_dicom_toolkit
-pause
+setlocal EnableExtensions DisableDelayedExpansion
+cd /d "%~dp0"
+set "PYTHONUTF8=1"
+set "VENV_PYTHON=%~dp0.venv\Scripts\python.exe"
+
+if not exist "%VENV_PYTHON%" (
+  echo ERROR: The development virtual environment was not found.
+  echo.
+  echo From PowerShell in this repository, run:
+  echo   python -m venv .venv
+  echo   .\.venv\Scripts\python.exe -m pip install --upgrade pip setuptools wheel
+  echo   .\.venv\Scripts\python.exe -m pip install -r .\rt_dicom_toolkit\requirements.txt
+  echo   .\.venv\Scripts\python.exe -m pip install -e .
+  echo.
+  pause
+  exit /b 1
+)
+
+"%VENV_PYTHON%" -m rt_dicom_toolkit
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" (
+  echo.
+  echo ERROR: RT DICOM Toolkit exited with code %EXIT_CODE%.
+  pause
+)
+exit /b %EXIT_CODE%

--- a/tests/test_development_launcher.py
+++ b/tests/test_development_launcher.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_start_gui_uses_only_the_development_virtual_environment():
+    launcher = (ROOT / "start_gui.bat").read_text(encoding="utf-8").lower()
+
+    assert 'set "venv_python=%~dp0.venv\\scripts\\python.exe"' in launcher
+    assert 'if not exist "%venv_python%"' in launcher
+    assert '"%venv_python%" -m rt_dicom_toolkit' in launcher
+    assert "python -m rt_dicom_toolkit" not in launcher.replace(
+        '"%venv_python%" -m rt_dicom_toolkit', ""
+    )
+
+
+def test_start_gui_explains_fresh_clone_setup():
+    launcher = (ROOT / "start_gui.bat").read_text(encoding="utf-8").lower()
+
+    assert "python -m venv .venv" in launcher
+    assert ".\\.venv\\scripts\\python.exe -m pip install" in launcher
+    assert "rt_dicom_toolkit\\requirements.txt" in launcher
+    assert "exit /b 1" in launcher
+
+
+def test_readme_documents_the_same_development_environment():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()
+
+    assert "python -m venv .venv" in readme
+    assert ".\\.venv\\scripts\\python.exe -m rt_dicom_toolkit" in readme
+    assert "start_gui.bat" in readme
+    assert "unconfigured system python" in readme


### PR DESCRIPTION
## Summary

- make `start_gui.bat` launch the repository's `.venv` instead of an arbitrary system Python
- show fresh-clone setup commands when `.venv` is missing
- document the Windows development setup and direct GUI command
- add regression tests for the launcher and README instructions

## Validation

- `.\.venv\Scripts\python.exe -c "import pydicom, rt_dicom_toolkit; import rt_dicom_toolkit.gui"`
- `.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider --basetemp <workspace-temp> tests` — 19 passed, 2 skipped
- `.\.venv\Scripts\python.exe -m pip check` — no broken requirements
- `git diff --check`

## Scope

This changes only development startup behavior, documentation, and tests. It does not change DICOM processing semantics or include patient data.