### PR TITLE
Prepare v0.0.1 release

### DIFF
--- a/docs/windows_offline_installation.md
+++ b/docs/windows_offline_installation.md
@@ -43,7 +43,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\prepare_offline_bund
 Output:
 
 ```text
-dist\rt-dicom-toolkit-offline-win64-0.0.0.zip
+dist\rt-dicom-toolkit-offline-win64-0.0.1.zip
 ```
 
 The script:
@@ -66,13 +66,13 @@ itself requires comparison with the separately recorded hash.
 Copy this file:
 
 ```text
-dist\rt-dicom-toolkit-offline-win64-0.0.0.zip
+dist\rt-dicom-toolkit-offline-win64-0.0.1.zip
 ```
 
 When practical, verify the copied ZIP:
 
 ```powershell
-Get-FileHash .\rt-dicom-toolkit-offline-win64-0.0.0.zip -Algorithm SHA256
+Get-FileHash .\rt-dicom-toolkit-offline-win64-0.0.1.zip -Algorithm SHA256
 ```
 
 Patient DICOM and local `DICOM/` or `DICOM_LOGS/` directories are not included.

--- a/rt_dicom_toolkit/__init__.py
+++ b/rt_dicom_toolkit/__init__.py
@@ -2,7 +2,7 @@
 RT DICOM Toolkit - radiotherapy DICOM anonymization and validation.
 """
 
-__version__ = '0.0.0'
+__version__ = '0.0.1'
 
 from .anonymizer import RTDicomAnonymizer
 from .validator import RTDicomValidator

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rt_dicom_toolkit",
-    version="0.0.0",
+    version="0.0.1",
     packages=find_packages(),
     install_requires=[
         "pydicom>=2.4.4,<3.1",


### PR DESCRIPTION
## Summary

- bump the package and runtime version from `0.0.0` to `0.0.1`
- update the active Windows offline bundle filename examples
- preserve the historical `v0.0.0` validation record

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider --basetemp <workspace-temp> tests` — 19 passed, 2 skipped
- package metadata version: `0.0.1`
- runtime `__version__`: `0.0.1`
- `.\.venv\Scripts\python.exe -m pip check` — no broken requirements
- `git diff --check`

## Scope

This release preparation changes version metadata and current offline-installation documentation only. It does not change DICOM processing semantics or include patient data.